### PR TITLE
UICKeyChainStore: rename TestHost target to UICTestHost.

### DIFF
--- a/Lib/Configurations/Tests.xcconfig
+++ b/Lib/Configurations/Tests.xcconfig
@@ -6,9 +6,9 @@ INFOPLIST_FILE = UICKeyChainStoreTests/Info.plist;
 PRODUCT_BUNDLE_IDENTIFIER = com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier);
 PRODUCT_NAME = $(TARGET_NAME);
 
-TEST_HOST[sdk=iphone*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
-TEST_HOST[sdk=appletv*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
-TEST_HOST[sdk=macosx*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/Contents/MacOS/TestHost;
+TEST_HOST[sdk=iphone*] = $(BUILT_PRODUCTS_DIR)/UICTestHost.app/UICTestHost;
+TEST_HOST[sdk=appletv*] = $(BUILT_PRODUCTS_DIR)/UICTestHost.app/UICTestHost;
+TEST_HOST[sdk=macosx*] = $(BUILT_PRODUCTS_DIR)/UICTestHost.app/Contents/MacOS/UICTestHost;
 
 LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks;
 LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks;

--- a/Lib/UICKeyChainStore.xcodeproj/project.pbxproj
+++ b/Lib/UICKeyChainStore.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		14796A5F1C1CD9B500169D09 /* UICKeyChainStoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UICKeyChainStoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		14796A691C1CD9C900169D09 /* libUICKeyChainStore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUICKeyChainStore.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		14796A791C1CDB8A00169D09 /* libUICKeyChainStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = libUICKeyChainStore.xcconfig; path = Configurations/libUICKeyChainStore.xcconfig; sourceTree = "<group>"; };
-		148993CF1D8F2515000132F7 /* TestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		148993CF1D8F2515000132F7 /* UICTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UICTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		148993D21D8F2515000132F7 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		148993E21D8F2515000132F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14A59CA11A62CF6E006561CC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -144,7 +144,7 @@
 				14796A501C1CD9A500169D09 /* UICKeyChainStore.framework */,
 				14796A5F1C1CD9B500169D09 /* UICKeyChainStoreTests.xctest */,
 				14796A691C1CD9C900169D09 /* libUICKeyChainStore.a */,
-				148993CF1D8F2515000132F7 /* TestHost.app */,
+				148993CF1D8F2515000132F7 /* UICTestHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -270,9 +270,9 @@
 			productReference = 14796A691C1CD9C900169D09 /* libUICKeyChainStore.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		148993CE1D8F2515000132F7 /* TestHost */ = {
+		148993CE1D8F2515000132F7 /* UICTestHost */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 148993E31D8F2515000132F7 /* Build configuration list for PBXNativeTarget "TestHost" */;
+			buildConfigurationList = 148993E31D8F2515000132F7 /* Build configuration list for PBXNativeTarget "UICTestHost" */;
 			buildPhases = (
 				148993CB1D8F2515000132F7 /* Sources */,
 				148993CC1D8F2515000132F7 /* Frameworks */,
@@ -282,9 +282,9 @@
 			);
 			dependencies = (
 			);
-			name = TestHost;
+			name = UICTestHost;
 			productName = TestHost;
-			productReference = 148993CF1D8F2515000132F7 /* TestHost.app */;
+			productReference = 148993CF1D8F2515000132F7 /* UICTestHost.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -330,7 +330,7 @@
 				14796A461C1CD9A500169D09 /* UICKeyChainStore */,
 				14796A611C1CD9C900169D09 /* libUICKeyChainStore */,
 				14796A521C1CD9B500169D09 /* UICKeyChainStoreTests */,
-				148993CE1D8F2515000132F7 /* TestHost */,
+				148993CE1D8F2515000132F7 /* UICTestHost */,
 			);
 		};
 /* End PBXProject section */
@@ -399,7 +399,7 @@
 /* Begin PBXTargetDependency section */
 		14021B952169FD00006AD6AE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 148993CE1D8F2515000132F7 /* TestHost */;
+			target = 148993CE1D8F2515000132F7 /* UICTestHost */;
 			targetProxy = 14021B942169FD00006AD6AE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -507,7 +507,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		148993E31D8F2515000132F7 /* Build configuration list for PBXNativeTarget "TestHost" */ = {
+		148993E31D8F2515000132F7 /* Build configuration list for PBXNativeTarget "UICTestHost" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				148993E41D8F2515000132F7 /* Debug */,

--- a/Lib/UICKeyChainStore.xcodeproj/xcshareddata/xcschemes/UICTestHost.xcscheme
+++ b/Lib/UICKeyChainStore.xcodeproj/xcshareddata/xcschemes/UICTestHost.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "148993CE1D8F2515000132F7"
-               BuildableName = "TestHost.app"
-               BlueprintName = "TestHost"
+               BuildableName = "UICTestHost.app"
+               BlueprintName = "UICTestHost"
                ReferencedContainer = "container:UICKeyChainStore.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -33,8 +33,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "148993CE1D8F2515000132F7"
-            BuildableName = "TestHost.app"
-            BlueprintName = "TestHost"
+            BuildableName = "UICTestHost.app"
+            BlueprintName = "UICTestHost"
             ReferencedContainer = "container:UICKeyChainStore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -56,8 +56,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "148993CE1D8F2515000132F7"
-            BuildableName = "TestHost.app"
-            BlueprintName = "TestHost"
+            BuildableName = "UICTestHost.app"
+            BlueprintName = "UICTestHost"
             ReferencedContainer = "container:UICKeyChainStore.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -75,8 +75,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "148993CE1D8F2515000132F7"
-            BuildableName = "TestHost.app"
-            BlueprintName = "TestHost"
+            BuildableName = "UICTestHost.app"
+            BlueprintName = "UICTestHost"
             ReferencedContainer = "container:UICKeyChainStore.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>


### PR DESCRIPTION
The TestHost target has the same name as the one we use in Lightricks.
This casused some builds to fail as Xcode cannot differentiate between
the targets.